### PR TITLE
Fix Removed compatibility lecagy color entries

### DIFF
--- a/flavor.toml
+++ b/flavor.toml
@@ -174,9 +174,6 @@ rules = [
 	# Fallback
 	{ url = "*", fg = "#83c092" },
 	{ url = "*/", fg = "#a7c080" },
-	# Legacy (for older yazi versions)
-	{ name = "*", fg = "#83c092" },
-	{ name = "*/", fg = "#a7c080" },
 ]
 
 # : }}}


### PR DESCRIPTION
Fix for the following:

```bash
TOML parse error at line 178, column 2
    |
178 | 	{ name = "*", fg = "#83c092" },
    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
at least one of `url` or `mime` must be specified
```

Name was renamed to url in [Yazi v25.12.29](https://github.com/sxyazi/yazi/releases/tag/v25.12.29) (released December 29, 2025).

I removed the following legacy code since they are no longer supported.

This follows the issue [6](https://github.com/Chromium-3-Oxide/everforest-medium.yazi/issues/6) opened

PS: thanks for your work!